### PR TITLE
Handle GetCurrentDirectory required buffer size return value

### DIFF
--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -932,7 +932,11 @@ namespace kernel32 {
 		std::filesystem::path cwd = std::filesystem::current_path();
 		std::string path = files::pathToWindows(cwd);
 
-		assert(path.size() < uSize);
+		// If the buffer is too small, return the required buffer size.
+		// (Add 1 to include the NUL terminator)
+		if (path.size() + 1 > uSize) {
+			return path.size() + 1;
+		}
 
 		strcpy(lpBuffer, path.c_str());
 		return path.size();


### PR DESCRIPTION
When the output buffer size is too small, GetCurrentDirectory does nothing and simply returns the larger required size.

https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-getcurrentdirectory#return-value

Needed to run Code Warrior 4 mwcc.exe with no arguments, displaying usage/help message.

(Still unable to compile/preprocess with CW4 mwcc.exe)