### PR TITLE
Build static binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,25 +4,18 @@ jobs:
   build_and_test:
     name: Build and test
     runs-on: ubuntu-latest
-    container:
-      image: ubuntu:focal
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install GCC multilib
+      - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y cmake file gcc-multilib g++-multilib unzip wget
-
-      - name: Configure
-        # Replace with RelWithDebInfo when -O2 crash is fixed
-        run: |
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_BUILD_TYPE=Debug
+          sudo apt-get update
+          sudo apt-get install -y file unzip wget
 
       - name: Build
-        run: cmake --build build
+        env:
+          DOCKER_BUILDKIT: 1
+        run: docker build --target export --output build .
 
       - name: Test
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,23 @@
-FROM ubuntu:20.04 as build
+# Build stage
+FROM --platform=linux/i386 alpine:latest AS build
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        g++ \
-        g++-multilib \
-        cmake \
-        ninja-build
+# Install dependencies
+RUN apk add --no-cache cmake ninja g++ linux-headers binutils
 
+# Copy source files
 COPY . /wibo
 
+# Build static binary
 # Replace with RelWithDebInfo when -O2 crash is fixed
-RUN cmake -S /wibo -B /wibo/build -G Ninja -DCMAKE_BUILD_TYPE=Debug
-RUN cmake --build /wibo/build
+RUN cmake -S /wibo -B /wibo/build -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-static" \
+    && cmake --build /wibo/build \
+    && strip -g /wibo/build/wibo
 
+# Export binary (usage: docker build --target export --output build .)
+FROM scratch AS export
+COPY --from=build /wibo/build/wibo .
 
-FROM ubuntu:22.04
-
-RUN dpkg --add-architecture i386 \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        libstdc++6:i386
-
+# Runnable container
+FROM alpine:latest
 COPY --from=build /wibo/build/wibo /usr/local/sbin/wibo
-
 CMD /usr/local/sbin/wibo


### PR DESCRIPTION
This updates the Dockerfile to build a fully static i386 binary using Alpine Linux & musl libc.
This allows easily using it on non-x86 architectures via `qemu-i386`, and avoids depending on the installed libstdc++ version.

The release binary grows from ~0.8MB to ~1.8MB, but I think the benefits are more than worth it.
As a bonus, the resulting Docker image is nearly 20x smaller:
```
REPOSITORY               TAG       IMAGE ID       CREATED          SIZE
wibo                     latest    e033ebc1e00e   15 minutes ago   8.86MB
ghcr.io/decompals/wibo   latest    74a67030a46e   3 weeks ago      157MB
```