### PR TITLE
Pass absolute path to exe in argv[0]

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -175,10 +175,15 @@ int main(int argc, char **argv) {
 	}
 
 	// Build a command line
-	std::string cmdLine = "\"" + files::pathToWindows(std::filesystem::absolute(argv[1])) + "\"";
-	for (int i = 2; i < argc; i++) {
-		cmdLine += ' ';
-		std::string arg = argv[i];
+	std::string cmdLine;
+	for (int i = 1; i < argc; i++) {
+		std::string arg;
+		if (i == 1) {
+			arg = files::pathToWindows(std::filesystem::absolute(argv[1]));
+		} else {
+			cmdLine += ' ';
+			arg = argv[i];
+		}
 		bool needQuotes = arg.find_first_of("\\\" \t\n") != std::string::npos;
 		if (needQuotes)
 			cmdLine += '"';

--- a/main.cpp
+++ b/main.cpp
@@ -175,9 +175,9 @@ int main(int argc, char **argv) {
 	}
 
 	// Build a command line
-	std::string cmdLine;
-	for (int i = 1; i < argc; i++) {
-		if (i != 1) cmdLine += ' ';
+	std::string cmdLine = "\"" + files::pathToWindows(std::filesystem::absolute(argv[1])) + "\"";
+	for (int i = 2; i < argc; i++) {
+		cmdLine += ' ';
 		std::string arg = argv[i];
 		bool needQuotes = arg.find_first_of("\\\" \t\n") != std::string::npos;
 		if (needQuotes)


### PR DESCRIPTION
Before, argv[0] was a relative path with forward slashes, which MWCC didn't like.