### PR TITLE
Various fixes for mwcc/mwld

### DIFF
--- a/common.h
+++ b/common.h
@@ -8,7 +8,7 @@
 
 // On Windows, the incoming stack is aligned to a 4 byte boundary.
 // force_align_arg_pointer will realign the stack to match GCC's 16 byte alignment.
-#define WIN_ENTRY __attribute__((force_align_arg_pointer))
+#define WIN_ENTRY __attribute__((force_align_arg_pointer, callee_pop_aggregate_return(0)))
 #define WIN_FUNC WIN_ENTRY __attribute__((stdcall))
 #define DEBUG_LOG(...) wibo::debug_log(__VA_ARGS__)
 

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -565,6 +565,13 @@ namespace kernel32 {
 	unsigned int WIN_FUNC GetFileAttributesA(const char *lpFileName) {
 		auto path = files::pathFromWindows(lpFileName);
 		DEBUG_LOG("GetFileAttributesA(%s)... (%s)\n", lpFileName, path.c_str());
+
+		// See ole32::CoCreateInstance
+		if (endsWith(path, "/license.dat")) {
+			DEBUG_LOG("MWCC license override\n");
+			return 0x80; // FILE_ATTRIBUTE_NORMAL
+		}
+
 		auto status = std::filesystem::status(path);
 
 		wibo::lastError = 0;

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -875,7 +875,7 @@ namespace kernel32 {
 		return 1;
 	}
 
-	int FileTimeToLocalFileTime(const FILETIME *lpFileTime, FILETIME *lpLocalFileTime) {
+	int WIN_FUNC FileTimeToLocalFileTime(const FILETIME *lpFileTime, FILETIME *lpLocalFileTime) {
 		DEBUG_LOG("FileTimeToLocalFileTime\n");
 		// we live on Iceland
 		*lpLocalFileTime = *lpFileTime;

--- a/files.cpp
+++ b/files.cpp
@@ -22,7 +22,7 @@ namespace files {
 
 		// Return as-is if it exists, else traverse the filesystem looking for
 		// a path that matches case insensitively
-		std::filesystem::path path = std::filesystem::path(str);
+		std::filesystem::path path = std::filesystem::path(str).lexically_normal();
 		if (std::filesystem::exists(path)) {
 			return path;
 		}
@@ -58,7 +58,7 @@ namespace files {
 	}
 
 	std::string pathToWindows(const std::filesystem::path &path) {
-		std::string str = path;
+		std::string str = path.lexically_normal();
 
 		if (path.is_absolute()) {
 			str.insert(0, "Z:");

--- a/files.h
+++ b/files.h
@@ -1,4 +1,5 @@
 #include <filesystem>
+#include <string>
 
 namespace files {
 	std::filesystem::path pathFromWindows(const char *inStr);
@@ -8,4 +9,8 @@ namespace files {
 	void *getStdHandle(uint32_t nStdHandle);
 	unsigned int setStdHandle(uint32_t nStdHandle, void *hHandle);
 	void init();
+}
+
+static bool endsWith(const std::string &str, const std::string &suffix) {
+	return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }


### PR DESCRIPTION
`callee_pop_aggregate_return(0)` isn't actually necessary for any of our functions (yet), but matches the Windows x86 ABI (https://gcc.gnu.org/onlinedocs/gcc/x86-Function-Attributes.html)