### PR TITLE
Use correct token for docker deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Test
         run: |
-          wget https://cdn.discordapp.com/attachments/727918646525165659/917185027656286218/GC_WII_COMPILERS.zip
+          wget https://cdn.discordapp.com/attachments/727918646525165659/1129759991696457728/GC_WII_COMPILERS.zip
           unzip GC_WII_COMPILERS.zip
           MWCIncludes=. build/wibo GC/2.7/mwcceppc.exe -c test/test.c -Itest
           file test.o

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     name: Build and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -25,7 +25,7 @@ jobs:
           file test.o
 
       - name: Upload build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: wibo
           path: build/wibo

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Docker meta
         id: meta
@@ -18,24 +19,24 @@ jobs:
           images: ghcr.io/decompals/wibo
 
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: mkst
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push to Github registry (latest)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: ghcr.io/decompals/wibo:latest
         if: ${{ ! startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push to Github registry (versioned)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
I've learnt this week that I've been doing docker deployments from GHA wrong. We should be using the `secrets.GITHUB_TOKEN` rather than my own PAT :) Also taken the opportunity to bump the various deps.