### PR TITLE
Ensure we don't reallocate during 2GB address space block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(Filesystem REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -Wall -fno-pie -no-pie")
+
 include_directories(.)
 add_executable(wibo
     dll/advapi32.cpp

--- a/main.cpp
+++ b/main.cpp
@@ -264,7 +264,7 @@ static bool blockUpper2GB() {
 			holdingMapStart = std::max(holdingMapStart, FILL_MEMORY_ABOVE);
 
 			DEBUG_LOG("Mapping %08x-%08x\n", holdingMapStart, holdingMapEnd);
-			void* holdingMap = mmap((void*) holdingMapStart, holdingMapEnd - holdingMapStart, PROT_READ, MAP_ANONYMOUS|MAP_FIXED_NOREPLACE|MAP_PRIVATE, -1, 0);
+			void* holdingMap = mmap((void*) holdingMapStart, holdingMapEnd - holdingMapStart, PROT_READ, MAP_ANONYMOUS|MAP_FIXED|MAP_PRIVATE, -1, 0);
 
 			if (holdingMap == MAP_FAILED) {
 				perror("Failed to create holding map");


### PR DESCRIPTION
- ~~Adds `procLine.reserve(0x8000);` to ensure that the `std::string` doesn't cause memory allocation between reading `/proc/self/maps` and the `mmap` calls.~~ Replaced with Linux syscalls and stack buffer to avoid any allocations.
- ~~Replaces `MAP_FIXED` with `MAP_FIXED_NOREPLACE` (Linux 4.17+) to ensure that we bail if our mapping would overwrite an existing one.~~
- Moves this logic into a separate method `blockUpper2GB` to simplify cleanup.
- Adds `-fno-pie -no-pie` cflags to ensure that we're not using PIE. (Probably unnecessary, but seems good)