### PR TITLE
Add Fibre local storage (Fls*) functions for armcc

### DIFF
--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -2040,7 +2040,7 @@ namespace kernel32 {
 	}
 
 	unsigned int WIN_FUNC FlsSetValue(unsigned int dwFlsIndex, void *lpFlsData) {
-		// DEBUG_LOG("FlsSetValue(%u, %p)\n", dwFlsIndex, lpFlsValue);
+		// DEBUG_LOG("FlsSetValue(%u, %p)\n", dwFlsIndex, lpFlsData);
 		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_FLS_VALUES && flsValuesUsed[dwFlsIndex]) {
 			flsValues[dwFlsIndex] = lpFlsData;
 			return 1;

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -2016,7 +2016,7 @@ namespace kernel32 {
 
 	unsigned int WIN_FUNC FlsFree(unsigned int dwFlsIndex) {
 		DEBUG_LOG("FlsFree(%u)\n", dwFlsIndex);
-		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_TLS_VALUES && flsValuesUsed[dwFlsIndex]) {
+		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_FLS_VALUES && flsValuesUsed[dwFlsIndex]) {
 			flsValuesUsed[dwFlsIndex] = false;
 			return 1;
 		} else {

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -1993,6 +1993,63 @@ namespace kernel32 {
 		*Target = Value;
 		return initial;
 	}
+
+	// These are effectively a copy/paste of the Tls* functions
+	enum { MAX_FLS_VALUES = 100 };
+	static bool flsValuesUsed[MAX_FLS_VALUES] = { false };
+	static void *flsValues[MAX_FLS_VALUES];
+	int WIN_FUNC FlsAlloc(void *lpCallback) {
+		DEBUG_LOG("FlsAlloc (lpCallback: %x)\n", lpCallback);
+		// If the function succeeds, the return value is an FLS index initialized to zero.
+		for (size_t i = 0; i < MAX_FLS_VALUES; i++) {
+			if (flsValuesUsed[i] == false) {
+				flsValuesUsed[i] = true;
+				flsValues[i] = 0;
+				DEBUG_LOG("...returning %d\n", i);
+				return i;
+			}
+		}
+		DEBUG_LOG("...returning nothing\n");
+		wibo::lastError = 1;
+		return 0xFFFFFFFF; // FLS_OUT_OF_INDEXES
+	}
+
+	unsigned int WIN_FUNC FlsFree(unsigned int dwFlsIndex) {
+		DEBUG_LOG("FlsFree(%u)\n", dwFlsIndex);
+		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_TLS_VALUES && flsValuesUsed[dwFlsIndex]) {
+			flsValuesUsed[dwFlsIndex] = false;
+			return 1;
+		} else {
+			wibo::lastError = 1;
+			return 0;
+		}
+	}
+
+	void *WIN_FUNC FlsGetValue(unsigned int dwFlsIndex) {
+		// DEBUG_LOG("FlsGetValue(%u)", dwTlsIndex);
+		void *result = nullptr;
+		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_TLS_VALUES && flsValuesUsed[dwFlsIndex]) {
+			result = flsValues[dwFlsIndex];
+			// See https://learn.microsoft.com/en-us/windows/win32/api/fibersapi/nf-fibersapi-flsgetvalue
+			wibo::lastError = ERROR_SUCCESS;
+		} else {
+			wibo::lastError = 1;
+		}
+		// DEBUG_LOG(" -> %p\n", result);
+		return result;
+	}
+
+	unsigned int WIN_FUNC FlsSetValue(unsigned int dwFlsIndex, void *lpFlsData) {
+		// DEBUG_LOG("TlsSetValue(%u, %p)\n", dwTlsIndex, lpTlsValue);
+		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_FLS_VALUES && flsValuesUsed[dwFlsIndex]) {
+			flsValues[dwFlsIndex] = lpFlsData;
+			return 1;
+		} else {
+			wibo::lastError = 1;
+			return 0;
+		}
+	}
+
 }
 
 static void *resolveByName(const char *name) {
@@ -2180,6 +2237,12 @@ static void *resolveByName(const char *name) {
 	if (strcmp(name, "InterlockedIncrement") == 0) return (void *) kernel32::InterlockedIncrement;
 	if (strcmp(name, "InterlockedDecrement") == 0) return (void *) kernel32::InterlockedDecrement;
 	if (strcmp(name, "InterlockedExchange") == 0) return (void *) kernel32::InterlockedExchange;
+
+	// fibersapi.h
+	if (strcmp(name, "FlsAlloc") == 0) return (void *) kernel32::FlsAlloc;
+	if (strcmp(name, "FlsFree") == 0) return (void *) kernel32::FlsFree;
+	if (strcmp(name, "FlsSetValue") == 0) return (void *) kernel32::FlsSetValue;
+	if (strcmp(name, "FlsGetValue") == 0) return (void *) kernel32::FlsGetValue;
 
 	return 0;
 }

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -2028,7 +2028,7 @@ namespace kernel32 {
 	void *WIN_FUNC FlsGetValue(unsigned int dwFlsIndex) {
 		// DEBUG_LOG("FlsGetValue(%u)", dwFlsIndex);
 		void *result = nullptr;
-		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_TLS_VALUES && flsValuesUsed[dwFlsIndex]) {
+		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_FLS_VALUES && flsValuesUsed[dwFlsIndex]) {
 			result = flsValues[dwFlsIndex];
 			// See https://learn.microsoft.com/en-us/windows/win32/api/fibersapi/nf-fibersapi-flsgetvalue
 			wibo::lastError = ERROR_SUCCESS;

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -2026,7 +2026,7 @@ namespace kernel32 {
 	}
 
 	void *WIN_FUNC FlsGetValue(unsigned int dwFlsIndex) {
-		// DEBUG_LOG("FlsGetValue(%u)", dwTlsIndex);
+		// DEBUG_LOG("FlsGetValue(%u)", dwFlsIndex);
 		void *result = nullptr;
 		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_TLS_VALUES && flsValuesUsed[dwFlsIndex]) {
 			result = flsValues[dwFlsIndex];

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -2040,7 +2040,7 @@ namespace kernel32 {
 	}
 
 	unsigned int WIN_FUNC FlsSetValue(unsigned int dwFlsIndex, void *lpFlsData) {
-		// DEBUG_LOG("TlsSetValue(%u, %p)\n", dwTlsIndex, lpTlsValue);
+		// DEBUG_LOG("FlsSetValue(%u, %p)\n", dwFlsIndex, lpFlsValue);
 		if (dwFlsIndex >= 0 && dwFlsIndex < MAX_FLS_VALUES && flsValuesUsed[dwFlsIndex]) {
 			flsValues[dwFlsIndex] = lpFlsData;
 			return 1;


### PR DESCRIPTION
I dunno if there is a better way than copy/paste to support these?

Closes #50:
```
$ ~/github/wibo/build/wibo armcc.exe
Product: unknown
Component: unknown
Tool: armcc [5040081]

Usage:         armcc [options] file1 file2 ... filen
Main options:
        
--arm          Generate ARM code
--thumb        Generate Thumb code
--c90          Switch to C mode (default for .c files)
--cpp          Switch to C++ mode (default for .cpp files)
-O0            Minimum optimization
-O1            Restricted optimization for debugging
-O2            High optimization
-O3            Maximum optimization
-Ospace        Optimize for codesize
-Otime         Optimize for maximum performance
--cpu <cpu>    Select CPU to generate code for
--cpu list     Output a list of all the selectable CPUs
--device <dev> Set the target device type
--device list  Output a list of all the selectable devices
-o <file>      Name the final output file of the compilation
-c             Compile only, do not link
--asm          Output assembly code as well as object code
-S             Output assembly code instead of object code
--interleave   Interleave source with disassembly (use with --asm or -S)
-E             Preprocess the C source code only
-D<symbol>     Define <symbol> on entry to the compiler
-g             Generate tables for high-level debugging
-I<directory>  Include <directory> on the #include search path
```

Note: just tried to use the Tls* functions, but armcc uses both FLS and TLS, so that's a no-go!