### PR TITLE
[TEMPORARY FIX] Fix issues with the stack not being resized correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(Filesystem REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -Wall -fno-pie -no-pie")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -Wall -fno-pie -no-pie -D_LARGEFILE64_SOURCE")
 
 include_directories(.)
 add_executable(wibo

--- a/main.cpp
+++ b/main.cpp
@@ -310,7 +310,7 @@ static void blockUpper2GB() {
 			holdingMapStart = std::max(holdingMapStart, FILL_MEMORY_ABOVE);
 
 			// DEBUG_LOG("Mapping %08x-%08x\n", holdingMapStart, holdingMapEnd);
-			void* holdingMap = mmap((void*) holdingMapStart, holdingMapEnd - holdingMapStart, PROT_READ, MAP_ANONYMOUS|MAP_FIXED|MAP_PRIVATE, -1, 0);
+			void* holdingMap = mmap((void*) holdingMapStart, holdingMapEnd - holdingMapStart, PROT_READ | PROT_WRITE, MAP_ANONYMOUS|MAP_FIXED|MAP_PRIVATE, -1, 0);
 
 			if (holdingMap == MAP_FAILED) {
 				perror("Failed to create holding map");


### PR DESCRIPTION
This PR * very hackily * fixes #64 and the issues with mwldeppc in the xenoblade CI by allowing writes to the blocker regions we use to prevent libc from allocating in the upper 2GB of memory.

See discussion from https://discord.com/channels/710646040331681844/991954626448457828/1188187281056600094 onwards - this is only intended as a temporary solution, to tide over programs this breaks until the implementation of a custom heap allocator.