### PR TITLE
Add regression testing based on decomp.me scratches

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -30,5 +30,6 @@ jobs:
         shell: bash
         run: |
           git clone https://github.com/ConorBobbleHat/wibo-test-suite
-          ./wibo-test-suite/setup.sh
-          ./wibo-test-suite/run_compare_wine_wibo.sh build/wibo
+          cd wibo-test-suite
+          ./setup.sh
+          ./run_compare_wine_wibo.sh ../build/wibo

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -26,10 +26,20 @@ jobs:
       - name: Build release
         run: docker build --build-arg build_type=Release --target export --output build .
 
-      - name: Test
+      - name: Clone test suite
         shell: bash
         run: |
-          git clone https://github.com/ConorBobbleHat/wibo-test-suite
+          git clone --recursive https://github.com/ConorBobbleHat/wibo-test-suite
+          
+      - name: Cache compilers
+        uses: actions/cache@v3
+        with:
+          path: wibo-test-suite/decomp.me/backend/compilers/download_cache
+          key: ${{ runner.os }}-compilers-${{ hashFiles('backend/compilers/compilers.*.yaml') }}
+
+      - name: Run test suite
+        shell: bash
+        run: |
           cd wibo-test-suite
           ./setup.sh
-          ./run_compare_wine_wibo.sh ../build/wibo
+          ./run_compare_wine_wibo.sh $(realpath ../build/wibo)

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build_and_test:
-    name: Build and test
+    name: Regression test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,7 +29,6 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          mv build_debug/wibo build/wibo_debug
           git clone https://github.com/ConorBobbleHat/wibo-test-suite
           ./wibo-test-suite/setup.sh
           ./wibo-test-suite/run_compare_wine_wibo.sh build/wibo

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: wibo-test-suite/decomp.me/backend/compilers/download_cache
-          key: ${{ runner.os }}-compilers-${{ hashFiles('backend/compilers/compilers.*.yaml') }}
+          key: ${{ runner.os }}-compilers-${{ hashFiles('wibo-test-suite/decomp.me/backend/compilers/compilers.*.yaml') }}
 
       - name: Run test suite
         shell: bash

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,35 @@
+name: Regression
+
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+  pull_request:
+
+env:
+  DOCKER_BUILDKIT: 1
+
+jobs:
+  build_and_test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y file unzip wget
+          pipx install poetry 
+
+      - name: Build release
+        run: docker build --build-arg build_type=Release --target export --output build .
+
+      - name: Test
+        shell: bash
+        run: |
+          mv build_debug/wibo build/wibo_debug
+          git clone https://github.com/ConorBobbleHat/wibo-test-suite
+          ./wibo-test-suite/setup.sh
+          ./wibo-test-suite/run_compare_wine_wibo.sh build/wibo

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -21,6 +21,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y file unzip wget dos2unix binutils-arm-none-eabi binutils-powerpc-linux-gnu binutils-mips-linux-gnu
+          
+          sudo dpkg --add-architecture i386
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update -qq
+          sudo apt-get install -yqq --allow-downgrades libc6:i386 libgcc-s1:i386 libstdc++6:i386 wine
+          
           pipx install poetry 
 
       - name: Build release
@@ -37,6 +43,14 @@ jobs:
           path: wibo-test-suite/decomp.me/backend/compilers/download_cache
           key: ${{ runner.os }}-compilers-${{ hashFiles('wibo-test-suite/decomp.me/backend/compilers/compilers.*.yaml') }}
 
+      - name: Wine setup
+        shell: bash
+        run: |
+          mkdir -p "${WINEPREFIX}"
+          wineboot --init
+        env:
+          WINEPREFIX: /tmp/wine  
+          
       - name: Run test suite
         shell: bash
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y file unzip wget
+          sudo apt-get install -y file unzip wget dos2unix binutils-arm-none-eabi binutils-powerpc-linux-gnu binutils-mips-linux-gnu
           pipx install poetry 
 
       - name: Build release


### PR DESCRIPTION
because what good is writing a program if you don't put it through the twelve labours of hercules?
***
This PR implements regressions tests against all the compilers [decomp.me](https://decomp.me) uses wibo to run. It pulls in a static bank of decomp.me scratches (hosted [here](https://github.com/ConorBobbleHat/wibo-test-suite) for the moment), runs the current wibo build against all of them, and compares the output assembly to ground-truth compilations generated with wine.

This PR only directly adds a new CI workflow that pulls in and calls the repo above - most of the new methodology and explanations of are located there.

the new tests are failing for the moment - this seems to be the same bug recorded in #62