### PR TITLE
Add GetTempPathA

### DIFF
--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -642,7 +642,7 @@ namespace kernel32 {
 
 		const char* tmp_dir;
 		if (!(tmp_dir = getenv("WIBO_TMP_DIR"))) {
-			tmp_dir = "Z:\\tmp";
+			tmp_dir = "Z:\\tmp\\";
 		}
 
 		strcpy(lpBuffer, tmp_dir);

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -633,6 +633,22 @@ namespace kernel32 {
 		}
 	}
 
+	DWORD WIN_FUNC GetTempPathA(DWORD nBufferLength, LPSTR lpBuffer) {
+		DEBUG_LOG("GetTempPathA\n");
+
+		if ((nBufferLength == 0) || (lpBuffer == 0)) {
+			return 0;
+		}
+
+		const char* tmp_dir;
+		if (!(tmp_dir = getenv("WIBO_TMP_DIR"))) {
+			tmp_dir = "Z:\\tmp";
+		}
+
+		strcpy(lpBuffer, tmp_dir);
+		return strlen(tmp_dir);
+	}
+
 	struct FILETIME {
 		unsigned int dwLowDateTime;
 		unsigned int dwHighDateTime;
@@ -2265,6 +2281,7 @@ static void *resolveByName(const char *name) {
 	if (strcmp(name, "GetFileType") == 0) return (void *) kernel32::GetFileType;
 	if (strcmp(name, "FileTimeToLocalFileTime") == 0) return (void *) kernel32::FileTimeToLocalFileTime;
 	if (strcmp(name, "GetFileInformationByHandle") == 0) return (void *) kernel32::GetFileInformationByHandle;
+	if (strcmp(name, "GetTempPathA") == 0) return (void *) kernel32::GetTempPathA;
 
 	// sysinfoapi.h
 	if (strcmp(name, "GetSystemTime") == 0) return (void *) kernel32::GetSystemTime;


### PR DESCRIPTION
Defaults to `/tmp` but can be overridden with WIBO_TMP_DIR environment variable, e.g.
```
WIBO_TMP_DIR=z:\\home\\mark ~/github/wibo/build/wibo pspsnc.exe -S test.c -o test.s
```

This function is needed to run `pspsnc.exe`.