### PR TITLE
Add trailing periods support to `FindFirstFileA`

### DIFF
--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -723,7 +723,10 @@ namespace kernel32 {
 		auto path = files::pathFromWindows(lpFileName);
 		DEBUG_LOG("FindFirstFileA %s (%s)\n", lpFileName, path.c_str());
 
-		assert(strchr(path.c_str(), '*') == NULL && "wildcards are not supported yet :c");
+		if (strchr(path.c_str(), '*') != NULL) {
+			printf("path: %s\n", path.c_str());
+			assert(!"wildcards are not supported yet :c");
+		}
 
 		lpFindFileData->ftCreationTime = defaultFiletime;
 		lpFindFileData->ftLastAccessTime = defaultFiletime;

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -119,6 +119,7 @@ namespace kernel32 {
 	}
 
 	uint32_t WIN_FUNC GetLastError() {
+		DEBUG_LOG("GetLastError() -> %u\n", wibo::lastError);
 		return wibo::lastError;
 	}
 
@@ -276,6 +277,7 @@ namespace kernel32 {
 	}
 
 	int WIN_FUNC GetSystemDefaultLangID() {
+		DEBUG_LOG("STUB GetSystemDefaultLangID\n");
 		return 0;
 	}
 
@@ -774,6 +776,7 @@ namespace kernel32 {
 	}
 
 	int WIN_FUNC FindNextFileA(void *hFindFile, WIN32_FIND_DATA<char> *lpFindFileData) {
+		DEBUG_LOG("FindNextFileA(%p, %p)\n", hFindFile, lpFindFileData);
 		// Special value from FindFirstFileA
 		if (hFindFile == (void *) 1) {
 			wibo::lastError = ERROR_NO_MORE_FILES;
@@ -1279,7 +1282,7 @@ namespace kernel32 {
 	}
 
 	unsigned int WIN_FUNC SetConsoleCtrlHandler(void *HandlerRoutine, unsigned int Add) {
-		DEBUG_LOG("SetConsoleCtrlHandler\n");
+		DEBUG_LOG("STUB SetConsoleCtrlHandler\n");
 		// This is a function that gets called when doing ^C
 		// We might want to call this later (being mindful that it'll be stdcall I think)
 
@@ -1302,6 +1305,7 @@ namespace kernel32 {
 	};
 
 	unsigned int WIN_FUNC GetConsoleScreenBufferInfo(void *hConsoleOutput, CONSOLE_SCREEN_BUFFER_INFO *lpConsoleScreenBufferInfo) {
+		DEBUG_LOG("GetConsoleScreenBufferInfo(%p, %p)\n", hConsoleOutput, lpConsoleScreenBufferInfo);
 		// Tell a lie
 		// mwcc doesn't care about anything else
 		lpConsoleScreenBufferInfo->dwSize_x = 80;
@@ -1786,6 +1790,7 @@ namespace kernel32 {
 			return 1;
 
 		// sure.. we have that feature...
+		DEBUG_LOG("  IsProcessorFeaturePresent: we don't know about feature %u, lying...\n", processorFeature);
 		return 1;
 	}
 

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -723,11 +723,6 @@ namespace kernel32 {
 		auto path = files::pathFromWindows(lpFileName);
 		DEBUG_LOG("FindFirstFileA %s (%s)\n", lpFileName, path.c_str());
 
-		if (strchr(path.c_str(), '*') != NULL) {
-			printf("path: %s\n", path.c_str());
-			assert(!"wildcards are not supported yet :c");
-		}
-
 		lpFindFileData->ftCreationTime = defaultFiletime;
 		lpFindFileData->ftLastAccessTime = defaultFiletime;
 		lpFindFileData->ftLastWriteTime = defaultFiletime;

--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -1372,7 +1372,7 @@ namespace kernel32 {
 	}
 
 	unsigned int WIN_FUNC GetCurrentDirectoryA(unsigned int uSize, char *lpBuffer) {
-		DEBUG_LOG("GetCurrentDirectoryA(%u, %p)\n", uSize, lpBuffer);
+		DEBUG_LOG("GetCurrentDirectoryA(%u, %p)", uSize, lpBuffer);
 
 		std::filesystem::path cwd = std::filesystem::current_path();
 		std::string path = files::pathToWindows(cwd);
@@ -1380,9 +1380,11 @@ namespace kernel32 {
 		// If the buffer is too small, return the required buffer size.
 		// (Add 1 to include the NUL terminator)
 		if (path.size() + 1 > uSize) {
+			DEBUG_LOG(" !! Buffer too small: %i, %i\n", path.size() + 1, uSize);
 			return path.size() + 1;
 		}
 
+		DEBUG_LOG(" -> %s\n", path.c_str());
 		strcpy(lpBuffer, path.c_str());
 		return path.size();
 	}

--- a/files.cpp
+++ b/files.cpp
@@ -32,7 +32,6 @@ namespace files {
 			return path;
 		}
 
-		path = path.lexically_normal();
 		std::filesystem::path newPath = ".";
 		bool followingExisting = true;
 		for (const auto& component : path) {


### PR DESCRIPTION
Adds support to handle directories with trailing periods (ie `include/.`) passed to `FindFirstFileA` and family.

I couldn't find docs on how the function should behave in this case (https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-findfirstfilea), but assuming it means "find anything on the passed directory" makes the program happy.

This was needed by "GCC 2.95.3 SN 1.14's `cpp.exe`"

I also added an assert in `FindFirstFileA` to check for wildcards and a few other unrelated logs. I can remove them if preferred.