### PR TITLE
Added quotation mark check in files::pathFromWindows

### DIFF
--- a/dll/kernel32.cpp
+++ b/dll/kernel32.cpp
@@ -226,6 +226,20 @@ namespace kernel32 {
 			// to prevent from doubling up on the target executable name
 			// (it appears as lpApplicationName, and as the first token in lpCommandLine)
 			arg = strtok(NULL, " ");
+
+			if (arg) {
+				// Trim all quotation marks from the start and the end of the string
+				while(*arg == '\"') {
+					arg++;
+				}
+
+				char* end = arg + strlen(arg) - 1;
+				while(end > arg && *end == '\"') {
+					*end = '\0';
+					end--;
+				}
+			}
+			
 			argv[current_arg_index++] = arg;
 		}
 

--- a/files.cpp
+++ b/files.cpp
@@ -15,11 +15,6 @@ namespace files {
 		std::string str = inStr;
 		std::replace(str.begin(), str.end(), '\\', '/');
 
-		// Detect quotation marks around path, and remove them
-		if (str.length() >= 2 && str.front() == '"' && str.back() == '"') {
-			str = str.substr(1, str.length() - 2);
-		}
-
 		// Remove "//?/" prefix
 		if (str.rfind("//?/", 0) == 0) {
 			str.erase(0, 4);

--- a/files.cpp
+++ b/files.cpp
@@ -15,6 +15,11 @@ namespace files {
 		std::string str = inStr;
 		std::replace(str.begin(), str.end(), '\\', '/');
 
+		// Detect quotation marks around path, and remove them
+		if (str.length() >= 2 && str.front() == '"' && str.back() == '"') {
+			str = str.substr(1, str.length() - 2);
+		}
+
 		// Remove "//?/" prefix
 		if (str.rfind("//?/", 0) == 0) {
 			str.erase(0, 4);


### PR DESCRIPTION
This PR checks if the path passed into pathFromWindows starts and ends with escaped quotation marks, and if yes, remove those from the string so that the rest of the parsing code runs correctly.
(This fixes an issue with SHC putting quotation marks around the path arguments passed into its sub-processes)