### PR TITLE
Integrate mimalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ include(FetchContent)
 FetchContent_Declare(
     mimalloc
     GIT_REPOSITORY https://github.com/microsoft/mimalloc.git
-    GIT_TAG        v3.1.5
+    GIT_TAG        dfa50c37d951128b1e77167dd9291081aa88eea4  # v3.1.5
 )
 FetchContent_MakeAvailable(mimalloc)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,28 @@ if(NOT CMAKE_BUILD_TYPE)
         "Build type options: Debug Release RelWithDebInfo MinSizeRel" FORCE)
 endif()
 
+set(CMAKE_C_FLAGS_INIT "-m32")
+set(CMAKE_CXX_FLAGS_INIT "-m32")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-m32")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-m32")
+
 project(wibo LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -fno-pie -no-pie -D_LARGEFILE64_SOURCE")
+
 find_package(Filesystem REQUIRED)
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -Wall -fno-pie -no-pie -D_LARGEFILE64_SOURCE")
+include(FetchContent)
+FetchContent_Declare(
+    mimalloc
+    GIT_REPOSITORY https://github.com/microsoft/mimalloc.git
+    GIT_TAG        v3.1.5
+)
+FetchContent_MakeAvailable(mimalloc)
+find_package(mimalloc REQUIRED)
 
 include_directories(.)
 add_executable(wibo
@@ -35,5 +49,5 @@ add_executable(wibo
     processes.cpp
     strutil.cpp
 )
-target_link_libraries(wibo PRIVATE std::filesystem)
+target_link_libraries(wibo PRIVATE std::filesystem mimalloc-static)
 install(TARGETS wibo DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ FetchContent_Declare(
     GIT_TAG        v3.1.5
 )
 FetchContent_MakeAvailable(mimalloc)
-find_package(mimalloc REQUIRED)
 
 include_directories(.)
 add_executable(wibo

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM --platform=linux/i386 alpine:latest AS build
 
 # Install dependencies
-RUN apk add --no-cache cmake ninja g++ linux-headers binutils
+RUN apk add --no-cache cmake ninja g++ linux-headers binutils git
 
 # Copy source files
 COPY . /wibo


### PR DESCRIPTION
musl libc's malloc is notoriously slow, and that ends up being what we're using when compiling the static release binaries. Instead, we can integrate [mimalloc](https://github.com/microsoft/mimalloc), a very fast and robust modern allocator. The dependency is fetched using CMake's FetchContent. Linking `mimalloc-static` automatically overrides C++ new/delete, as well as malloc/realloc/etc.

When testing, this cut almost a minute off of ac-decomp's build time:
```
real	2m40.719s
user	38m12.308s
sys	14m58.701s
```
to
```
real	1m50.328s
user	25m22.266s
sys	10m53.724s
```

In `kernel32.cpp`, we now explicitly use aligned allocations of 8 to match the described behavior of [GlobalAlloc](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-globalalloc) and the like.

This includes a minor fix for `InitOnceBeginInitialize`, and an implementation of `InitOnceComplete`, because I was too lazy to create a separate PR.