### PR TITLE
Add support for $PATH and Additional Path Utilities

### DIFF
--- a/files.h
+++ b/files.h
@@ -4,6 +4,7 @@
 namespace files {
 	std::filesystem::path pathFromWindows(const char *inStr);
 	std::string pathToWindows(const std::filesystem::path &path);
+	std::string which(const std::string &progname);
 	void *allocFpHandle(FILE *fp);
 	FILE *fpFromHandle(void *handle, bool pop = false);
 	void *getStdHandle(uint32_t nStdHandle);


### PR DESCRIPTION
Adds the ability to find the PE executable in $PATH. If not found, the legacy behavior remains.

Adds the `--unix-path`/`-du` and `--dos-path`/`-ud` options to provide the ability to convert between paths that might be created by utilities run by wibo or local filesystem paths that will be passed to programs run by wibo.