### PR TITLE
Revamp CLI --help and add --version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Docker meta
         id: meta
@@ -64,6 +66,10 @@ jobs:
           flavor: |
             latest=false
 
+      - name: Compute version
+        id: version
+        run: echo "wibo_version=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
+
       - name: Build Docker image
         id: docker-build
         uses: docker/build-push-action@v6
@@ -71,6 +77,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           build-args: |
             BUILD_TYPE=${{ matrix.build_type }}
+            WIBO_VERSION=${{ steps.version.outputs.wibo_version }}
           target: build
 
       - name: Tests
@@ -84,6 +91,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           build-args: |
             BUILD_TYPE=${{ matrix.build_type }}
+            WIBO_VERSION=${{ steps.version.outputs.wibo_version }}
           target: export
           outputs: |
             type=local,dest=dist
@@ -102,6 +110,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           build-args: |
             BUILD_TYPE=${{ matrix.build_type }}
+            WIBO_VERSION=${{ steps.version.outputs.wibo_version }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Docker image
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository == 'decompals/wibo'
         uses: docker/build-push-action@v6
         with:
           file: ${{ matrix.dockerfile }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 - `cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON` configures a 32-bit toolchain; ensure multilib packages are present.
 - `cmake --build build --target wibo` compiles the program and tests.
 - `./build/wibo /path/to/program.exe` runs a Windows binary. Use `WIBO_DEBUG=1` (or `--debug`/`-D`) for verbose logging. Use `--chdir`/`-C` to set the working directory.
-- `cmake -B build -DBUILD_TESTING=ON` + `ctest --test-dir build --output-on-failure` runs the self-checking WinAPI fixtures (requires `i686-w64-mingw32-gcc` and `i686-w64-mingw32-windres`).
+- `ctest --test-dir build --output-on-failure` runs the self-checking WinAPI fixtures (requires `i686-w64-mingw32-gcc` and `i686-w64-mingw32-windres`).
 - `clang-format -i path/to/file.cpp` and `clang-tidy path/to/file.cpp -p build` keep contributions aligned with the repo's tooling.
 
 ## Coding Style & Naming Conventions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,40 @@ set(CMAKE_SHARED_LINKER_FLAGS_INIT "-m32")
 
 project(wibo LANGUAGES C CXX)
 
+set(WIBO_VERSION "" CACHE STRING "Version string for the wibo binary; if empty, attempts to use git describe")
+
+if(NOT "${WIBO_VERSION}" STREQUAL "")
+    set(WIBO_VERSION_STRING "${WIBO_VERSION}")
+elseif(DEFINED ENV{WIBO_VERSION} AND NOT "$ENV{WIBO_VERSION}" STREQUAL "")
+    set(WIBO_VERSION_STRING "$ENV{WIBO_VERSION}")
+else()
+    find_package(Git QUIET)
+    if(GIT_FOUND)
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --always
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            RESULT_VARIABLE WIBO_GIT_DESCRIBE_RESULT
+            OUTPUT_VARIABLE WIBO_GIT_DESCRIBE_OUTPUT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        if(WIBO_GIT_DESCRIBE_RESULT EQUAL 0 AND NOT "${WIBO_GIT_DESCRIBE_OUTPUT}" STREQUAL "")
+            set(WIBO_VERSION_STRING "${WIBO_GIT_DESCRIBE_OUTPUT}")
+        endif()
+    endif()
+endif()
+
+if(NOT DEFINED WIBO_VERSION_STRING OR "${WIBO_VERSION_STRING}" STREQUAL "")
+    set(WIBO_VERSION_STRING "unknown")
+endif()
+
+set(WIBO_GENERATED_HEADER_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
+file(MAKE_DIRECTORY ${WIBO_GENERATED_HEADER_DIR})
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/version_info.h.in
+    ${WIBO_GENERATED_HEADER_DIR}/version_info.h
+    @ONLY
+)
+
 option(WIBO_ENABLE_FIXTURE_TESTS "Enable Win32 fixture tests (requires i686-w64-mingw32)" ON)
 option(WIBO_ENABLE_LIBURING "Enable liburing for asynchronous I/O" OFF)
 set(WIBO_ENABLE_LTO "AUTO" CACHE STRING "Enable link-time optimization (LTO)")
@@ -142,7 +176,7 @@ add_executable(wibo
 target_compile_definitions(wibo PRIVATE _GNU_SOURCE _FILE_OFFSET_BITS=64 _TIME_BITS=64)
 target_compile_features(wibo PRIVATE cxx_std_20)
 target_compile_options(wibo PRIVATE -Wall -Wextra -fno-pie -maccumulate-outgoing-args)
-target_include_directories(wibo PRIVATE dll src)
+target_include_directories(wibo PRIVATE dll src ${WIBO_GENERATED_HEADER_DIR})
 target_link_libraries(wibo PRIVATE mimalloc-obj)
 target_link_options(wibo PRIVATE -no-pie)
 if (WIBO_ENABLE_LIBURING)

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ ARG BUILD_TYPE=Release
 # Enable link-time optimization (LTO) (AUTO, ON, OFF)
 ARG ENABLE_LTO=AUTO
 
+# Version string (if not provided, defaults to "unknown")
+ARG WIBO_VERSION
+
 # Build static binary
 RUN cmake -S /wibo -B /wibo/build -G Ninja \
         -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" \
@@ -33,6 +36,7 @@ RUN cmake -S /wibo -B /wibo/build -G Ninja \
         -DMI_LIBC_MUSL:BOOL=ON \
         -DWIBO_ENABLE_LIBURING:BOOL=ON \
         -DWIBO_ENABLE_LTO:STRING="$ENABLE_LTO" \
+        -DWIBO_VERSION:STRING="$WIBO_VERSION" \
     && cmake --build /wibo/build --verbose \
     && ( [ "$BUILD_TYPE" != "Release" ] || strip -g /wibo/build/wibo )
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -30,10 +30,14 @@ ARG BUILD_TYPE=Release
 # Enable link-time optimization (LTO) (AUTO, ON, OFF)
 ARG ENABLE_LTO=AUTO
 
+# Version string (if not provided, defaults to "unknown")
+ARG WIBO_VERSION
+
 RUN cmake -S /wibo -B /wibo/build -G Ninja \
         -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" \
         -DWIBO_ENABLE_LIBURING:BOOL=ON \
         -DWIBO_ENABLE_LTO:STRING="$ENABLE_LTO" \
+        -DWIBO_VERSION:STRING="$WIBO_VERSION" \
     && cmake --build /wibo/build --verbose \
     && ( [ "$BUILD_TYPE" != "Release" ] || strip -g /wibo/build/wibo )
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A minimal, low-fuss wrapper that can run simple command-line 32-bit Windows binaries on 32-bit Linux - developed to run Windows compilers faster than Wine.
 
+Download the latest release from [GitHub releases](https://github.com/decompals/wibo/releases) or build from source.
+
 ## Building
 
 ```sh
@@ -11,19 +13,51 @@ cmake --build build
 
 Set `-DCMAKE_BUILD_TYPE=Release` to produce an optimized binary instead.
 
-## Running
+## Usage
 
 ```sh
-./build/wibo /path/to/program.exe [arguments...]
+wibo [options] <program.exe> [arguments...]
+wibo path [subcommand options] <path> [path...]
 ```
 
-Supported command line options:
+### General Options
 
-- `--help`: Print usage information.
-- `-D`, `--debug`: Enable shim debug logging (equivalent to `WIBO_DEBUG=1`).
-- `-C DIR`, `--chdir DIR`, `--chdir=DIR`: Change to `DIR` before running the guest program.
-- `--cmdline STRING`, `--cmdline=STRING`: Use `STRING` as the exact guest command line. (Including the program name as the first argument.)
-- `--`: Stop option parsing; following arguments are interpreted as the exact guest command line. (Including the program name as the first argument.)
+| Option          | Description                       |
+| --------------- | --------------------------------- |
+| `-h, --help`    | Show usage information and exit   |
+| `-V, --version` | Show version information and exit |
+
+### Runtime Options
+
+| Option             | Description                                                                                                      |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `-C, --chdir DIR`  | Change working directory before launching the program                                                            |
+| `-D, --debug`      | Enable debug logging (same as `WIBO_DEBUG=1`)                                                                    |
+| `--cmdline STRING` | Use `STRING` as the exact guest command line (must include the program name, e.g. `"test.exe a b c"`)            |
+| `--`               | Stop option parsing; following arguments are used verbatim as the guest command line, including the program name |
+
+### Subcommands
+
+| Subcommand | Description                                                                       |
+| ---------- | --------------------------------------------------------------------------------- |
+| `path`     | Convert between host and Windows-style paths (see `wibo path --help` for details) |
+
+### Examples
+
+#### Normal usage
+
+```sh
+wibo path/to/test.exe a b c
+wibo -C path/to test.exe a b c
+```
+
+#### Advanced: full control over the guest command line
+
+```sh
+wibo path/to/test.exe -- test.exe a b c
+wibo --cmdline 'test.exe a b c' path/to/test.exe
+wibo -- test.exe a b c
+```
 
 ## Tests
 
@@ -35,9 +69,12 @@ ctest --test-dir build --output-on-failure
 
 This will cross-compile the fixture executables, run them through `wibo`, and fail if any WinAPI expectations are not met.
 
----
+## Related Projects
 
-See also:
 * [taviso/loadlibrary](https://github.com/taviso/loadlibrary) - Initial inspiration for this project.
 * [evmar/retrowin32](https://github.com/evmar/retrowin32) - A similar project with different goals and architecture.
 * [decomp.me](https://decomp.me) - Collaborative decompilation website; uses wibo to run Windows compilers.
+
+## License
+
+wibo is licensed under the MIT License. See `LICENSE` for details.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,7 +148,7 @@ static void printHelp(const char *argv0, bool error) {
 	fprintf(out, "\n");
 	fprintf(out, "Runtime Options:\n");
 	fprintf(out, "  -C, --chdir DIR       Change working directory before launching the program\n");
-	fprintf(out, "  -D, --debug           Enable debug logging (same as WIBO_DEBUG=1)\n");
+	fprintf(out, "  -D, --debug           Enable debug logging (equivalent to WIBO_DEBUG=1)\n");
 	fprintf(out, "      --cmdline STRING  Use STRING as the exact guest command line\n");
 	fprintf(out, "                        (includes the program name, e.g. \"test.exe a b c\")\n");
 	fprintf(out, "      --                Stop option parsing; following arguments are used\n");
@@ -160,11 +160,11 @@ static void printHelp(const char *argv0, bool error) {
 	fprintf(out, "                        (see '%s path --help' for details)\n", exeName.c_str());
 	fprintf(out, "\n");
 	fprintf(out, "Examples:\n");
-	fprintf(out, "  # Typical usage\n");
+	fprintf(out, "  # Normal usage\n");
 	fprintf(out, "  %s path/to/test.exe a b c\n", exeName.c_str());
 	fprintf(out, "  %s -C path/to test.exe a b c\n", exeName.c_str());
 	fprintf(out, "\n");
-	fprintf(out, "  # Advanced forms: full control over the guest command line\n");
+	fprintf(out, "  # Advanced: full control over the guest command line\n");
 	fprintf(out, "  %s path/to/test.exe -- test.exe a b c\n", exeName.c_str());
 	fprintf(out, "  %s --cmdline 'test.exe a b c' path/to/test.exe\n", exeName.c_str());
 	fprintf(out, "  %s -- test.exe a b c\n", exeName.c_str());

--- a/src/version_info.h.in
+++ b/src/version_info.h.in
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace wibo {
+
+constexpr const char kVersionString[] = "@WIBO_VERSION_STRING@";
+
+} // namespace wibo


### PR DESCRIPTION
Example output:

```console
$ wibo
wibo 1.0.0-alpha.1

Usage:
  wibo [options] <program.exe> [arguments...]
  wibo path [subcommand options] <path> [path...]

General Options:
  -h, --help            Show this help message and exit
  -V, --version         Show version information and exit

Runtime Options:
  -C, --chdir DIR       Change working directory before launching the program
  -D, --debug           Enable debug logging (same as WIBO_DEBUG=1)
      --cmdline STRING  Use STRING as the exact guest command line
                        (includes the program name, e.g. "test.exe a b c")
      --                Stop option parsing; following arguments are used
                        verbatim as the guest command line, including the
                        program name

Subcommands:
  path                  Convert between host and Windows-style paths
                        (see 'wibo path --help' for details)

Examples:
  # Typical usage
  wibo path/to/test.exe a b c
  wibo -C path/to test.exe a b c

  # Advanced forms: full control over the guest command line
  wibo path/to/test.exe -- test.exe a b c
  wibo --cmdline 'test.exe a b c' path/to/test.exe
  wibo -- test.exe a b c
```

```console
$ wibo path
Usage:
  wibo path [options] <path> [path...]

Path Options (exactly one required):
  -u, --unix       Convert Windows paths to host (Unix-style) paths
  -w, --windows    Convert host (Unix-style) paths to Windows paths

General Options:
  -h, --help       Show this help message and exit

Examples:
  wibo path -u 'Z:\home\user'
  wibo path -w /home/user
```

```console
$ wibo --version
wibo 1.0.0-alpha.1
```