### PR TITLE
Exclude cmd.exe from process spawning

### DIFF
--- a/dll/kernel32/processthreadsapi.cpp
+++ b/dll/kernel32/processthreadsapi.cpp
@@ -635,9 +635,22 @@ BOOL WINAPI CreateProcessA(LPCSTR lpApplicationName, LPSTR lpCommandLine, LPSECU
 
 	bool useSearchPath = lpApplicationName == nullptr;
 	std::string application;
-	std::string commandLine = lpCommandLine ? lpCommandLine : "";
-	if (lpApplicationName) {
-		application = lpApplicationName;
+	std::string commandLine = "";
+    bool findNewApp = false;
+
+	if (lpCommandLine) {
+        commandLine = lpCommandLine;
+
+        std::string toRemove = "cmd.exe /c ";
+        size_t pos = commandLine.find(toRemove);
+        if (pos != std::string::npos) {
+            commandLine.erase(pos, toRemove.length());
+            findNewApp = true;
+        }
+	}
+
+	if (lpApplicationName && !findNewApp) {
+        application = lpApplicationName;
 	} else {
 		std::vector<std::string> arguments = wibo::splitCommandLine(commandLine.c_str());
 		if (arguments.empty()) {


### PR DESCRIPTION
Hello, this is a simple addition that prevents cmd.exe to be called directly.

I did perceive that ARMCC calls "cmd /c asmasm.exe" when theres assembly inside of c code, which is the reason why i made this patch, and a good example.

I tried to keep it minimal, please review