### PR TITLE
CI: fix Alpine static builds and ship a real 32-bit wibo-i686

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
             BUILD_TYPE=${{ matrix.build_type }}
             WIBO_VERSION=${{ steps.version.outputs.wibo_version }}
           target: export
+          platforms: ${{ matrix.platform || 'linux/amd64' }}
           outputs: |
             type=local,dest=dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --no-cache \
     clang-dev \
     cmake \
     coreutils \
+    gcc \
     git \
     linux-headers \
     lld \
@@ -16,6 +17,7 @@ RUN apk add --no-cache \
     make \
     mingw-w64-binutils \
     mingw-w64-gcc \
+    musl-dev \
     ninja \
     python3
 


### PR DESCRIPTION
Two independent fixes to the release/CI pipeline. Both are reproducible on a fresh checkout of `main`.

## 1. Alpine static builds are broken (all four static jobs fail)

`alpine:latest` advanced to 3.24.x (clang 22 / gcc 15.2 / cmake 4.2) and no longer pulls in `gcc` transitively. The static toolchain links with `clang --target=...-musl -static -fuse-ld=lld`, which needs the GCC runtime (`crtbeginT.o`, `libgcc`, `libgcc_eh`, `crtend.o`) plus the musl crt/libc. Without them the CMake compiler check fails:

```
ld.lld: error: cannot open crtbeginT.o: No such file or directory
ld.lld: error: unable to find library -lgcc
ld.lld: error: unable to find library -lgcc_eh
ld.lld: error: cannot open crtend.o: No such file or directory
```

**Fix:** install `gcc` and `musl-dev` explicitly in `Dockerfile`.

## 2. `wibo-i686` is actually a 64-bit binary

The `Export binary` step omits `platforms:`, so it always rebuilds for the host (`linux/amd64`) regardless of the matrix entry. The matrix platform only applies to the *test* step, not the exported artifact. As a result the static 32-bit release assets (`wibo-i686`, `wibo-i686-debug`) have been 64-bit `x86-64` ELF binaries — even though the README advertises `wibo-i686` as the primary 32-bit download.

This has been the case for every release since the i686/x86_64 split was introduced at `1.0.0-beta.3`:

| Release | `wibo-i686` arch |
|---|---|
| 1.0.0-beta.2 (single `wibo` asset) | ELF 32-bit ✅ |
| 1.0.0-beta.3 … 1.0.3 | ELF 64-bit ❌ |
| 1.1.0 / 1.1.1 | ELF 64-bit ❌ |

**Fix:** pass the matrix platform to the export build so the exported binary matches the platform that was tested.

## Validation

Local Docker builds mirroring CI:

- `linux/amd64`, `--target build` + `ctest`: builds and passes.
- `linux/386`, `--target export`: produces a flat `dist/wibo` that is now `ELF 32-bit LSB executable, Intel 80386`.

The two changes are independent and can be split into separate PRs if preferred.
