### PR TITLE
Detect a seccomp-blocked set_thread_area so wibo runs under AWS Lambda

### DIFF
--- a/src/setup_linux.cpp
+++ b/src/setup_linux.cpp
@@ -4,11 +4,14 @@
 #include "types.h"
 
 #include <array>
+#include <cerrno>
 #include <cstring>
 #include <mutex>
 
 #include <asm/ldt.h>
 #include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 namespace {
 
@@ -210,6 +213,43 @@ bool segmentSetupLocked(TEB *teb) {
 extern "C" void installSelectors(TEB *teb);
 extern "C" int setThreadArea64(int entryNumber, TEB *teb);
 
+namespace {
+
+// setThreadArea64 issues set_thread_area through `int 0x80`. Some seccomp
+// sandboxes block that compat path: AWS Lambda, for instance, kills the process
+// with SIGSYS when it runs. We can't just call it and recover, because the
+// filter may use a non-catchable KILL action rather than SECCOMP_RET_TRAP. So
+// probe it once in a forked child — if the child is killed by the filter (or the
+// syscall otherwise fails), treat set_thread_area as unavailable and let
+// tebThreadSetup fall back to modify_ldt. Callers hold g_tebSetupMutex and the
+// result is cached, so this forks at most once, during startup.
+bool setThreadAreaAvailable(TEB *teb) {
+	static int cached = -1;
+	if (cached >= 0) {
+		return cached != 0;
+	}
+	pid_t pid = fork();
+	if (pid == 0) {
+		_exit(setThreadArea64(g_threadAreaEntry, teb) >= 0 ? 0 : 1);
+	}
+	if (pid < 0) {
+		cached = 1; // can't probe; assume available and keep the existing behaviour
+		return true;
+	}
+	int status = 0;
+	pid_t w;
+	do {
+		w = waitpid(pid, &status, 0);
+	} while (w < 0 && errno == EINTR);
+	cached = (w == pid && WIFEXITED(status) && WEXITSTATUS(status) == 0) ? 1 : 0;
+	if (!cached) {
+		DEBUG_LOG("setup_linux: set_thread_area blocked by seccomp, using LDT\n");
+	}
+	return cached != 0;
+}
+
+} // namespace
+
 bool tebThreadSetup(TEB *teb) {
 	std::lock_guard guard(g_tebSetupMutex);
 
@@ -229,7 +269,7 @@ bool tebThreadSetup(TEB *teb) {
 	// Install ds/es selectors
 	installSelectors(teb);
 
-	if (g_threadAreaEntry != -2) {
+	if (g_threadAreaEntry != -2 && setThreadAreaAvailable(teb)) {
 		int ret = setThreadArea64(g_threadAreaEntry, teb);
 		if (ret >= 0) {
 			if (g_threadAreaEntry != ret) {


### PR DESCRIPTION
Picks up the thread from #113 — running wibo on AWS Lambda, the GC/2.0 `mwcceppc` dies with SIGSYS during thread setup. It's `setThreadArea64`: it makes its `set_thread_area` call via `int 0x80`, and Lambda's seccomp filter blocks the compat syscall path. The signal lands before the existing `modify_ldt` fallback can run, since that only triggers when `set_thread_area` *returns* an error.

I started from the SIGSYS-handler idea in the #113 review (catch the trap, rewrite the return to `-ENOSYS`, let the normal fallback take over). It's neat, but it doesn't actually work on Lambda: the filter there uses a **KILL** action, not `SECCOMP_RET_TRAP`, so the SIGSYS is uncatchable and a handler never runs. I confirmed it with a small probe — install an `SA_SIGINFO` SIGSYS handler, fire `int 0x80`/`set_thread_area`, and the process is killed outright (the handler's `si_code`/`si_arch` checks never get a chance).

So rather than catch the signal, this detects whether `set_thread_area` is usable by trying it once in a forked child. If the child gets killed by the filter (or the syscall fails), the parent treats it as unavailable and uses `modify_ldt`. Forking isolates the trap: a KILL action only takes down the child's process group, so the parent survives either way, and it works for both KILL and TRAP filters.

Tested on Lambda (x86_64): `mwcceppc -version` and real compiles work and produce correct PPC objects, no env vars or config. The setup log shows the fall-through:

```
setup_linux: set_thread_area blocked by seccomp, using LDT
setup_linux: Using FS selector 0x17
```

On a normal machine it's one extra `fork` at startup (cached, so at most once) and otherwise unchanged. If you'd rather not fork on the common path, I can gate it behind a `/proc/self/status` `Seccomp` check so it only probes when a filter is actually installed — happy to add that.

Scope note: this only covers the x86_64 compat path (the `int 0x80` in `setThreadArea64`); the 32-bit build's native `set_thread_area` is untouched.
