### PR TITLE
Fix missing SSIZE_MAX declaration by including <climits>

### DIFF
--- a/src/async_io_epoll.cpp
+++ b/src/async_io_epoll.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <atomic>
 #include <cerrno>
+#include <climits>
 #include <condition_variable>
 #include <cstdint>
 #include <deque>

--- a/src/async_io_kqueue.cpp
+++ b/src/async_io_kqueue.cpp
@@ -8,6 +8,7 @@
 #include <array>
 #include <atomic>
 #include <cerrno>
+#include <climits>
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>

--- a/src/files.cpp
+++ b/src/files.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <climits>
 #include <csignal>
 #include <cstddef>
 #include <cstdio>


### PR DESCRIPTION
src/files.cpp and src/async_io_epoll.cpp use SSIZE_MAX without including <climits>, relying on it being pulled in transitively by other headers. Newer glibc/libstdc++ (e.g. GCC 16 / glibc 2.43) no longer expose SSIZE_MAX this way, breaking the build. Added the explicit include to these files and to src/async_io_kqueue.cpp, which has the same latent issue.