### PR TITLE
Fix macOS Homebrew LLVM builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,11 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(CLANG_ROOT "/usr" CACHE PATH "Path to Clang installation")
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(CLANG_ROOT "/Library/Developer/CommandLineTools/usr/lib" CACHE PATH "Path to Clang installation")
+    # Prefer libclang from the compiler installation. This keeps Homebrew LLVM
+    # builds from mixing its clang executable with AppleClang's libclang.
+    get_filename_component(_CLANG_BIN_DIR "${CMAKE_C_COMPILER}" DIRECTORY)
+    get_filename_component(_CLANG_COMPILER_ROOT "${_CLANG_BIN_DIR}/.." ABSOLUTE)
+    set(CLANG_ROOT "${_CLANG_COMPILER_ROOT}" CACHE PATH "Path to Clang installation")
 endif()
 set(_LLVM_MIN_VER 17)
 set(_LLVM_MAX_VER 25)
@@ -333,7 +337,7 @@ endforeach()
 list(APPEND _CLANG_LIB_SUFFIXES llvm/lib lib lib64)
 find_library(LIBCLANG_LIBRARY
     NAMES libclang clang
-    HINTS ${CLANG_ROOT}
+    HINTS ${CLANG_ROOT} "/Library/Developer/CommandLineTools/usr/lib"
     PATH_SUFFIXES ${_CLANG_LIB_SUFFIXES}
 )
 if(NOT LIBCLANG_LIBRARY)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,7 +45,7 @@
       "name": "debug-macos",
       "displayName": "Debug",
       "description": "Debug build (64-bit macOS)",
-      "inherits": ["ninja-base"],
+      "inherits": ["ninja-base", "clang-base"],
       "binaryDir": "${sourceDir}/build/debug",
       "condition": {
         "type": "equals",
@@ -77,7 +77,7 @@
       "name": "release-macos",
       "displayName": "Release",
       "description": "Release build (64-bit macOS)",
-      "inherits": ["ninja-base"],
+      "inherits": ["ninja-base", "clang-base"],
       "binaryDir": "${sourceDir}/build/release",
       "condition": {
         "type": "equals",


### PR DESCRIPTION
On my machine, I have a more recent LLVM installation via Homebrew, which is not compatible with AppleClang.

This patch lets the macOS presets use the Clang installation selected through PATH and searches for libclang relative to that compiler. The Apple Command Line Tools location remains as a fallback. This prevents the build from mixing Homebrew Clang with Apple’s libclang and fixes trampoline generation.